### PR TITLE
Support multiple pronunciation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,22 +63,25 @@ result = mecab.parse("文")
 で、属性の値を知ることができます。
 
 サポートされている属性は以下のとおりです。
-| MeCabの項目 | Morphemeのproperty    | 出力例                 |
-| --------------- | ---------------- | ---------------------- |
-| 形態素の文字列  | token             | 渋谷, 行っ             |
-| 品詞            | pos0             | 名詞, 動詞             |
-| 品詞細分類1     | pos1             | 固有名詞, 自立         |
-| 品詞細分類2     | pos2             | 地域, None             |
-| 品詞細分類3     | pos3             | 一般, None             |
-| 活用型          | conjugation_type | None, 五段・カ行促音便 |
-| 活用形          | conjugation      | None, 連用タ接続       |
-| 原型            | stem_form        | 渋谷, 行く             |
-| 発音            | pronunciation    | シブヤ, イッ           |
-| <分類失敗時>    | unknown          | None, None             |
+| MeCabの項目    | Morphemeのproperty | propertyのtype         | 出力例                                 | 
+| -------------- | ------------------ | ---------------------- | -------------------------------------- | 
+| 形態素の文字列 | token              | `str`                  | '東京', '行っ'                         | 
+| 品詞           | pos0               | `str` or `None`        | '名詞', '動詞'                         | 
+| 品詞細分類1    | pos1               | `str` or `None`        | '固有名詞', '自立'                     | 
+| 品詞細分類2    | pos2               | `str` or `None`        | '地域', None                           | 
+| 品詞細分類3    | pos3               | `str` or `None`        | '一般', None                           | 
+| 活用型         | conjugation_type   | `str` or `None`        | None, '五段・カ行促音便'               | 
+| 活用形         | conjugation        | `str` or `None`        | None, '連用タ接続'                     | 
+| 原型           | stem_form          | `str` or `None`        | '東京', '行く'                         | 
+| 発音           | pronunciation      | `tuple[str]` or `None` | ('トウキョウ', 'トーキョー'), ('イッ') | 
+| <分類失敗時>   | unknown            | `str` or `None`        | None, None                             | 
 
 `token`は常に文字列が格納されます。
 
 それ以外の属性は、存在するときはその値の文字列、存在しない場合には`None`が格納されます。
+
+`pronunciation`のみ、発音が1つしかない場合でもタプルが格納されるため、`r.pronunciation[0]`などでアクセスしてください。  
+（IPA辞書の場合、MeCabの出力した発音2種がどちらも異なる場合にのみ、タプルの要素が2つになります。）
 
 `unknown`にはMeCabの出力を正しく分類できなかった際に、MeCabの出力結果が文字列としてそのまま格納されます。通常は`None`です。MeCabの辞書を正しく分類するために、[`dict_type`](#引数dict_typeについて)は正しく指定してください。
 

--- a/src/simple_mecab/mecab_wrapper.py
+++ b/src/simple_mecab/mecab_wrapper.py
@@ -167,25 +167,30 @@ class MeCabWrapper:
 
     def __extract(self, parsed_word: str) -> Morpheme:
         if self.__dict_type == 'ipadic':
-            surface, others = parsed_word.split('\t')
-            info = others.split(',')
+            surface, features = parsed_word.split('\t')
+            features_list = features.split(',')
+            pronunciation = None
+            if len(features_list) > 7:
+                pronunciation = [features_list[7]]
+                if len(features_list) > 8 and features_list[7] != features_list[8]:
+                    pronunciation.append(features_list[8])
+                pronunciation = tuple(pronunciation)
             ret = Morpheme(surface,
-                           info[0] if len(
-                               info) > 0 and info[0] not in self.__none_pattern else None,
-                           info[1] if len(
-                               info) > 1 and info[1] not in self.__none_pattern else None,
-                           info[2] if len(
-                               info) > 2 and info[2] not in self.__none_pattern else None,
-                           info[3] if len(
-                               info) > 3 and info[3] not in self.__none_pattern else None,
-                           info[4] if len(
-                               info) > 4 and info[4] not in self.__none_pattern else None,
-                           info[5] if len(
-                               info) > 5 and info[5] not in self.__none_pattern else None,
-                           info[6] if len(
-                               info) > 6 and info[6] not in self.__none_pattern else None,
-                           info[7] if len(
-                               info) > 7 and info[7] not in self.__none_pattern else None,
+                           features_list[0] if len(
+                               features_list) > 0 and features_list[0] not in self.__none_pattern else None,
+                           features_list[1] if len(
+                               features_list) > 1 and features_list[1] not in self.__none_pattern else None,
+                           features_list[2] if len(
+                               features_list) > 2 and features_list[2] not in self.__none_pattern else None,
+                           features_list[3] if len(
+                               features_list) > 3 and features_list[3] not in self.__none_pattern else None,
+                           features_list[4] if len(
+                               features_list) > 4 and features_list[4] not in self.__none_pattern else None,
+                           features_list[5] if len(
+                               features_list) > 5 and features_list[5] not in self.__none_pattern else None,
+                           features_list[6] if len(
+                               features_list) > 6 and features_list[6] not in self.__none_pattern else None,
+                           pronunciation,
                            None)
             return ret
         elif self.__dict_type == 'unidic':

--- a/src/simple_mecab/morpheme.py
+++ b/src/simple_mecab/morpheme.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
 
 @dataclass
@@ -9,39 +9,39 @@ class Morpheme:
     Variables
     ---------
     token : str
-        形態素 （例：'食べ'）
+        形態素 （例：'東京', '行っ'）
 
     pos0 : str | None
         語の品詞 (part of speech)
-        （例：'動詞'）
+        （例：'名詞', '動詞'）
 
     pos1 : str | None
         品詞細分類1
-        （例：'代名詞'）
+        （例：'固有名詞', '自立'）
 
     pos2 : str | None
         品詞細分類2
-        （例：'一般'）
+        （例：'地域'）
 
     pos3 : str | None
         品詞細分類3
-        （例：'場所'）
+        （例：'一般'）
 
     conjugation_type : str | None
         活用型
-        （例：'下一段-バ行'）
+        （例：'五段・カ行促音便'）
 
     conjugation : str | None
         活用形
-        （例：'未然形-一般'）
+        （例：'連用タ接続'）
 
     stem_form : str | None
         原形
-        （例：'食べる'）
+        （例：'東京', '行く'）
 
-    pronunciation : str | None
+    pronunciation : tuple[str] | None
         発音
-        （例：'タベ'）
+        （例：('トウキョウ', 'トーキョー'), ('イッ')）
 
     unknown : str | None
         正常に抽出できなかった場合はここに入ります。
@@ -61,7 +61,7 @@ class Morpheme:
 
         Example
         -------
-        "渋谷", "行っ"
+        '東京', '行っ'
         """
         return self.__token
 
@@ -79,7 +79,7 @@ class Morpheme:
 
         Example
         -------
-        "名詞", "動詞", None
+        '名詞', '動詞', None
 
         格納される値は使用する辞書によって異なります。
         """
@@ -99,7 +99,7 @@ class Morpheme:
 
         Example
         -------
-        "固有名詞", "自立", None
+        '固有名詞', '自立', None
 
         格納される値は使用する辞書によって異なります。
         """
@@ -119,7 +119,7 @@ class Morpheme:
 
         Example
         -------
-        "地域", None
+        '地域', None
 
         格納される値は使用する辞書によって異なります。
         """
@@ -139,7 +139,7 @@ class Morpheme:
 
         Example
         -------
-        "一般", None
+        '一般', None
 
         格納される値は使用する辞書によって異なります。
         """
@@ -159,7 +159,7 @@ class Morpheme:
 
         Example
         -------
-        "五段・カ行促音便", None
+        '五段・カ行促音便', None
 
         格納される値は使用する辞書によって異なります。
         """
@@ -179,7 +179,7 @@ class Morpheme:
 
         Example
         -------
-        "連用タ接続", None
+        '連用タ接続', None
 
         格納される値は使用する辞書によって異なります。
         """
@@ -199,16 +199,16 @@ class Morpheme:
 
         Example
         -------
-        "渋谷", "行く", None
+        '東京', '行く', None
 
         格納される値は使用する辞書によって異なります。
         """
         return self.__stem_form
 
-    __pronunciation: Optional[str]
+    __pronunciation: Optional[Tuple[str]]
 
     @property
-    def pronunciation(self) -> Optional[str]:
+    def pronunciation(self) -> Optional[Tuple[str]]:
         """発音
 
         Returns
@@ -219,7 +219,7 @@ class Morpheme:
 
         Example
         -------
-        "シブヤ", "イッ", None
+        ('トウキョウ', 'トーキョー'), ('イッ'), None
 
         格納される値は使用する辞書によって異なります。
         """
@@ -234,7 +234,7 @@ class Morpheme:
         Returns
         -------
         str | None
-            要素を分類できなかった場合に、MeCabの結果のfeature部分を文字列として返します。
+            要素を分類できなかった場合に、MeCabの出力のfeature部分を文字列として返します。
             通常は`None`を返します。
 
         Example
@@ -254,7 +254,7 @@ class Morpheme:
                 f"conjugation_type={self.__conjugation_type.__repr__()}, "  # type: ignore
                 f"conjugation={self.__conjugation.__repr__()}, "  # type: ignore
                 f"stem_form={self.__stem_form.__repr__()}, "  # type: ignore
-                f"pronunciation={self.__pronunciation.__repr__()}, "  # type: ignore
+                f"pronunciation={self.__pronunciation.__repr__().replace(',)', ')')}, "  # type: ignore
                 f"unknown={self.__unknown.__repr__()})")  # type: ignore
 
     def __repr__(self) -> str:
@@ -266,5 +266,5 @@ class Morpheme:
                 f"{self.__conjugation_type.__repr__()}, "  # type: ignore
                 f"{self.__conjugation.__repr__()}, "  # type: ignore
                 f"{self.__stem_form.__repr__()}, "  # type: ignore
-                f"{self.__pronunciation.__repr__()}, "  # type: ignore
+                f"{self.__pronunciation.__repr__().replace(',)', ')')}, "  # type: ignore
                 f"{self.__unknown.__repr__()})")  # type: ignore


### PR DESCRIPTION
Change type of Morpheme.pronunciation to `tuple[str] | None` from `str | None`.